### PR TITLE
Add unit tests and command line arguments

### DIFF
--- a/FaceMaskDataset.py
+++ b/FaceMaskDataset.py
@@ -24,8 +24,8 @@ https://pytorch.org/tutorials/beginner/data_loading_tutorial.html
 #         return len(self.images)
 
 #     def __getitem__(self, idx):
-#         image_filename = f'{IMAGE_ROOT}maksssksksss' + str(idx) + '.png'
-#         label_filename = f'{ANNOTATION_ROOT}maksssksksss' + str(idx) + '.xml'        
+#         image_filename = IMAGE_ROOT + f'maksssksksss{idx}.png'
+#         label_filename = ANNOTATION_ROOT + f'maksssksksss{idx}.xml'        
 #         image = Image.open(image_filename)
 #         label = parseXML(label_filename)
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ npm install
 <!-- USAGE EXAMPLES -->
 ## Usage
 
+1. Download dataset from Kaggle.
+2. Set up `virtualenv`.
+3. Crop the images.
+```
+python crop.py
+```
+4. Run data augmentation
+```
+python augment.py
+```
+5. Run the pipeline.
+```
+python run_pipeline.py
+```
+
 Use this space to show useful examples of how a project can be used. Additional screenshots, code examples and demos work well in this space. You may also link to more resources.
 
 _For more examples, please refer to the [Documentation](https://example.com)_

--- a/config.py
+++ b/config.py
@@ -6,10 +6,31 @@ TODO: extend this file to be modified based on the command line arguments.
 """
 
 ARCHIVE_ROOT = './archive/'
-IMAGE_ROOT = f'{ARCHIVE_ROOT}images/'
-ANNOTATION_ROOT = f'{ARCHIVE_ROOT}annotations/'
-CROPPED_IMAGE_ROOT = f'{ARCHIVE_ROOT}cropped/'
-AUGMENTED_IMAGE_ROOT = f'{ARCHIVE_ROOT}augmented/'
+IMAGE_ROOT = ARCHIVE_ROOT + 'images/'
+ANNOTATION_ROOT = ARCHIVE_ROOT + 'annotations/'
+CROPPED_IMAGE_ROOT = ARCHIVE_ROOT + 'cropped/'
+AUGMENTED_IMAGE_ROOT = ARCHIVE_ROOT + 'augmented/'
 
 # verbose = False
 # etc...
+
+def build_description(title: str) -> str:
+    lines = [
+        title,
+        '',
+        'Charles Pan, Gilbert Rosal, & Dean Stratakos',
+        'CS 229: Machine Learning',
+        'October 20, 2020'
+    ]
+
+    max_length = max(len(l) for l in lines)
+    bar = f"+{'-' * (max_length + 2)}+"
+    description = f'{bar}\n'
+    for line in lines:
+        total_padding = max_length - len(line)
+        left_padding = int(total_padding / 2)
+        right_padding = int((total_padding + 1) / 2)
+        description += f"| {' ' * left_padding}{line}{' ' * right_padding} |\n"
+    description += f'{bar}'
+
+    return description

--- a/preprocess.py
+++ b/preprocess.py
@@ -3,11 +3,12 @@ file: preprocess.py
 -------------------
 Parses XML files.
 """
+import argparse
 import os
 import pprint
 import xml.etree.ElementTree as ET
 
-from config import IMAGE_ROOT, ANNOTATION_ROOT
+from config import IMAGE_ROOT, ANNOTATION_ROOT, build_description
 
 def parseXML(xml_filename: str) -> dict:
     """ This function generates an annotation dictionary representation of
@@ -34,13 +35,15 @@ def parseXML(xml_filename: str) -> dict:
             annotation[item.tag] = item.text             
     return annotation
 
-def single_file_test():
+def single_file_test(xml_base):
     """ Tests the parseXML function for a single XML file.
     """
+    annotation = parseXML(ANNOTATION_ROOT + xml_base)
     pp = pprint.PrettyPrinter(indent=4)
-
-    annotation = parseXML(f'{ANNOTATION_ROOT}maksssksksss0.xml')
     pp.pprint(annotation)
+
+def get_num_images() -> int:
+    return len(os.listdir(IMAGE_ROOT))
 
 def main():
     """ Collects all of the images and annotations from the archive directory.
@@ -51,7 +54,7 @@ def main():
         annotations ([dict]): List of the parsed annotations
     """
 
-    # sort by the image id (i.e. maksssksksss[id].png)
+    # sort by the image id (i.e. maksssksksss[image id].png)
     image_bases = list(sorted(os.listdir(IMAGE_ROOT),
                               key=lambda x: int(x[12:-4])))
     annotations = list(sorted(os.listdir(ANNOTATION_ROOT),
@@ -61,12 +64,23 @@ def main():
         annotations ({len(annotations)})'
     
     print(f'The dataset contains {len(image_bases)} data points')
-    annotations = [parseXML(f'{ANNOTATION_ROOT}{annotation}')
+    annotations = [parseXML(ANNOTATION_ROOT + annotation)
                     for annotation in annotations]
 
     return image_bases, annotations
 
 if __name__ == '__main__':
-    main()
-    # single_file_test()
+    arg_parser = argparse.ArgumentParser(
+        description=build_description('Preprocess module'),
+        formatter_class=argparse.RawTextHelpFormatter)
+    arg_parser.add_argument("-t", "--test",
+        help="parse a single XML file",
+        action="store_true")
+    arg_parser.add_argument("-f", "--file",
+        help="XML file name to run tests on",
+        default='maksssksksss0.xml')
+    args = arg_parser.parse_args()
+
+    if args.test: single_file_test(args.file)
+    else: main()
     

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,33 +1,13 @@
 import argparse
-from argparse import RawTextHelpFormatter
 
+from config import build_description
 import preprocess
-
-def build_description() -> str:
-    lines = [
-        'Face Mask Detection Pipeline',
-        '',
-        'Charles Pan, Gilbert Rosal, & Dean Stratakos',
-        'CS 229: Machine Learning',
-        'October 20, 2020'
-    ]
-
-    max_length = max(len(l) for l in lines)
-    bar = f"+{'-' * (max_length + 2)}+"
-    description = f'{bar}\n'
-    for line in lines:
-        total_padding = max_length - len(line)
-        left_padding = int(total_padding / 2)
-        right_padding = int((total_padding + 1) / 2)
-        description += f"| {' ' * left_padding}{line}{' ' * right_padding} |\n"
-    description += f'{bar}'
-
-    return description
 
 def parse_args() -> dict:
     """ Parse the input arguments """
-    arg_parser = argparse.ArgumentParser(description=build_description(),
-        formatter_class=RawTextHelpFormatter)
+    arg_parser = argparse.ArgumentParser(
+        description=build_description('Face Mask Detection Pipeline'),
+        formatter_class=argparse.RawTextHelpFormatter)
     arg_parser.add_argument("model",
         help="1 for logistic regression, 2 for SVM, 3 for CNN", type=int,
         choices=[1, 2, 3], default=3)

--- a/visualize.py
+++ b/visualize.py
@@ -4,8 +4,9 @@ file: visualize.py
 Visualizes images by drawing boxes to represent annotations. The color
 of the box depends on the class of the annotation.
 
-It should take around two and a half minutes to process 833 images.
+It should take around two and a half minutes to process 853 images.
 """
+import argparse
 import os
 
 import matplotlib.pyplot as plt
@@ -14,28 +15,32 @@ from PIL import Image
 import numpy as np
 from tqdm import tqdm
 
-from config import ARCHIVE_ROOT, IMAGE_ROOT, ANNOTATION_ROOT
+from config import ARCHIVE_ROOT, IMAGE_ROOT, ANNOTATION_ROOT, build_description
 import preprocess
 
-VISUALIZATION_ROOT = f'{ARCHIVE_ROOT}visualizations/'
+VISUALIZATION_ROOT = ARCHIVE_ROOT + 'visualizations/'
 COLORS = {
     'with_mask': 'lime',
     'mask_weared_incorrect': 'yellow',
     'without_mask': 'red'
     }
 
-def visualize_image(image_base: str, annotation: dict, interactive: bool=False):
+def visualize_image(image_id: int, interactive: bool=False):
     """ Creates a new image by drawing the bounding boxes from the annotation
     in one of three colors.
 
     Args:
-        image_base (str): The base filename of the image
-        annotation (dict): The corresponding annotation
+        image_id (int): The id of the image to visualize
         interactive (bool, optional): If true, the new image will be shown as a
             pop-up. Execution will be paused until the pop-up window is closed.
             Defaults to False.
     """
-    image = np.array(Image.open(f'{IMAGE_ROOT}{image_base}'), dtype=np.uint8)
+    image = np.array(
+        Image.open(IMAGE_ROOT + f'maksssksksss{image_id}.png'),
+        dtype=np.uint8)
+    annotation = preprocess.parseXML(
+        ANNOTATION_ROOT + f'maksssksksss{image_id}.xml')
+    
     fig, ax = plt.subplots(1)
     ax.imshow(image)
 
@@ -51,17 +56,29 @@ def visualize_image(image_base: str, annotation: dict, interactive: bool=False):
             facecolor='none')
         ax.add_patch(rect)
 
-    id = int(image_base[12:-4])          # image id (i.e. maksssksksss[id].png)
-    plt.title(f'Image {id}')
+    plt.title(f'Image {image_id}')
     if interactive: plt.show()
-    else: fig.savefig(f'{VISUALIZATION_ROOT}image' + str(id) + '.png')
+    else: fig.savefig(VISUALIZATION_ROOT + f'image-{image_id}.png')
     plt.close()
 
-if __name__ == '__main__':
-    os.makedirs(f'{ARCHIVE_ROOT}visualizations', exist_ok=True)
+def main():
+    os.makedirs(ARCHIVE_ROOT + 'visualizations/', exist_ok=True)
 
-    image_bases, annotations = preprocess.main()
-    with tqdm(total=len(image_bases)) as progress_bar:
-        for image_base, annotation in zip(image_bases, annotations):
-            visualize_image(image_base, annotation)
-            progress_bar.update()
+    for index in tqdm(range(preprocess.get_num_images())):
+        visualize_image(index)
+
+if __name__ == '__main__':
+    arg_parser = argparse.ArgumentParser(
+        description=build_description('Image visualization module'),
+        formatter_class=argparse.RawTextHelpFormatter)
+    arg_parser.add_argument("-t", "--test",
+        help="visualize a single image",
+        action="store_true")
+    arg_parser.add_argument("-i", "--image_id",
+        help="id of the image to visualize",
+        type=int,
+        default=0)
+    args = arg_parser.parse_args()
+
+    if args.test: visualize_image(args.image_id, interactive=True)
+    else: main()


### PR DESCRIPTION
Add command line arguments including test flags for several modules.
Move build_description() to config.py for argparse across modules.
Change CSV labels to integers.
Change CSV structure and image file names to reflect the structure
'image-{image_id}-{face_id}-{augment_id}.png'.

NOTE: For the visualize.py unit test, I was running into a Segmentation
Fault on plt.show(). I ran `pip install --upgrade matplotlib` to fix it.